### PR TITLE
Fix parsing of JARs that have single-path entries

### DIFF
--- a/src/main/java/meghanada/location/LocationSearcher.java
+++ b/src/main/java/meghanada/location/LocationSearcher.java
@@ -676,6 +676,9 @@ public class LocationSearcher {
                 .filter(
                     e -> {
                       Path p = Paths.get(e.getName());
+                      if (p.getNameCount() < 2) {
+                        return false;
+                      }
                       Path subpath = p.subpath(1, p.getNameCount());
                       return subpath.toString().equals(s);
                     })


### PR DESCRIPTION
For example, the Akka JAR (for some reason) has a zip file entry called
just `"akka/"`. The current stream filter would fail on that.