### PR TITLE
Support smart completion/squeeze some bugs 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ bazel-*
 *.log
 .vscode
 .#*.*
+/.nb-gradle/

--- a/server/src/main/java/meghanada/completion/JavaCompletion.java
+++ b/server/src/main/java/meghanada/completion/JavaCompletion.java
@@ -38,7 +38,12 @@ import meghanada.completion.matcher.PrefixMatcher;
 import meghanada.config.Config;
 import meghanada.index.IndexDatabase;
 import meghanada.project.Project;
-import meghanada.reflect.*;
+import meghanada.reflect.CandidateUnit;
+import meghanada.reflect.CandidateUnit.MemberType;
+import meghanada.reflect.ClassIndex;
+import meghanada.reflect.FieldDescriptor;
+import meghanada.reflect.MemberDescriptor;
+import meghanada.reflect.MethodDescriptor;
 import meghanada.reflect.asm.CachedASMReflector;
 import meghanada.utils.ClassNameUtils;
 import meghanada.utils.FileUtils;
@@ -776,6 +781,7 @@ public class JavaCompletion {
           }
         }
       } catch (Exception ignored) {
+        log.catching(ignored);
       }
     }
     return typeOrMember;

--- a/server/src/main/java/meghanada/completion/JavaCompletion.java
+++ b/server/src/main/java/meghanada/completion/JavaCompletion.java
@@ -787,12 +787,12 @@ public class JavaCompletion {
     return (c1, c2) -> {
       boolean b1 = false, b2 = false;
       if (c1 instanceof MethodDescriptor) {
-        b1 = c1.getReturnType().endsWith(type);
+        b1 = c1.getReturnType().replace(", ", ",").endsWith(type);
       } else if (c1 instanceof FieldDescriptor) {
         b1 = c1.getType().endsWith(type);
       }
       if (c2 instanceof MethodDescriptor) {
-        b2 = c2.getReturnType().endsWith(type);
+        b2 = c2.getReturnType().replace(", ", ",").endsWith(type);
       } else if (c2 instanceof FieldDescriptor) {
         b2 = c2.getType().endsWith(type);
       }

--- a/server/src/main/java/meghanada/completion/JavaCompletion.java
+++ b/server/src/main/java/meghanada/completion/JavaCompletion.java
@@ -235,7 +235,6 @@ public class JavaCompletion {
     final CompletionMatcher classMatcher = getClassCompletionMatcher(prefix);
     // add this member
     completionThisMembers(typeScope, prefix, result, matcher);
-    completionThisMembers(prefix, result, fqcn);
 
     if (fqcn.contains(ClassNameUtils.INNER_MARK)) {
       // add parent

--- a/server/src/test/java/meghanada/completion/JavaCompletionTest.java
+++ b/server/src/test/java/meghanada/completion/JavaCompletionTest.java
@@ -102,7 +102,7 @@ public class JavaCompletionTest extends GradleTestBase {
     assertEquals(1, staticLog.size());
 
     final Collection<? extends CandidateUnit> pos =
-        timeIt(() -> completion.completionAt(file, 16, 8, "po"));
+        timeIt(() -> completion.completionAt(file, 22, 8, "po"));
     pos.forEach(a -> System.out.println(a.getDeclaration()));
     assertEquals(1, pos.size());
   }
@@ -208,6 +208,76 @@ public class JavaCompletionTest extends GradleTestBase {
         timeIt(() -> completion.completionAt(file, 79, 35, "Dia"));
     units.forEach(a -> System.out.println(a.getDisplayDeclaration()));
     assertEquals(2329, units.size());
+  }
+
+  @Test
+  public void testSmartCompletionNoType() throws Exception {
+    JavaCompletion completion = getCompletion();
+    File file =
+      new File(
+               project.getProjectRootPath(), "./src/main/java/meghanada/analyze/JavaAnalyzer.java")
+      .getCanonicalFile();
+    assertTrue(file.exists());
+    final Collection<? extends CandidateUnit> units =
+      timeIt(() -> completion.completionAt(file, 88, 6, "*diagnostic*fileObject#"));
+    units.forEach(a -> System.out.println(a.getDisplayDeclaration()));
+    CandidateUnit unit = (CandidateUnit) (units.toArray())[0];
+    assertEquals(unit.getName(), "getSource");
+  }
+
+  @Test
+  public void testSmartCompletionWithType() throws Exception {
+    JavaCompletion completion = getCompletion();
+    File file =
+      new File(
+               project.getProjectRootPath(), "./src/main/java/meghanada/analyze/JavaAnalyzer.java")
+      .getCanonicalFile();
+    assertTrue(file.exists());
+    final Collection<? extends CandidateUnit> units =
+      timeIt(() -> completion.completionAt(file, 88, 6, "*kind*String#"));
+    units.forEach(a -> System.out.println(a.getDisplayDeclaration()));
+    Object[] objs = (units.toArray());
+    CandidateUnit unit1 = (CandidateUnit) objs[0];
+    CandidateUnit unit2 = (CandidateUnit) objs[1];
+    assertEquals(unit1.getName(), "name");
+    assertEquals(unit2.getName(), "toString");
+  }
+
+  @Test
+  public void testSmartCompletionPrimaryType() throws Exception {
+    JavaCompletion completion = getCompletion();
+    File file =
+      new File(
+               project.getProjectRootPath(), "./src/main/java/meghanada/analyze/JavaAnalyzer.java")
+      .getCanonicalFile();
+    assertTrue(file.exists());
+    final Collection<? extends CandidateUnit> units =
+      timeIt(() -> completion.completionAt(file, 304, 4, "*code*int#"));
+    units.forEach(a -> System.out.println(a.getDisplayDeclaration()));
+    Object[] objs = (units.toArray());
+    CandidateUnit unit1 = (CandidateUnit) objs[0];
+    CandidateUnit unit2 = (CandidateUnit) objs[1];
+    CandidateUnit unit3 = (CandidateUnit) objs[2];
+    CandidateUnit unit4 = (CandidateUnit) objs[3];
+    assertEquals(unit1.getName(), "length");
+    assertEquals(unit2.getName(), "hashCode");
+    assertEquals(unit3.getName(), "indexOf");
+    assertEquals(unit4.getName(), "lastIndexOf");
+  }
+
+  public void testSmartCompletionGenericType() throws Exception {
+    JavaCompletion completion = getCompletion();
+    File file =
+      new File(
+               project.getProjectRootPath(), "./src/main/java/meghanada/analyze/JavaAnalyzer.java")
+      .getCanonicalFile();
+    assertTrue(file.exists());
+    final Collection<? extends CandidateUnit> units =
+      timeIt(() -> completion.completionAt(file, 192, 22, "a"));
+    units.forEach(a -> System.out.println(a.getDisplayDeclaration()));
+    Object[] objs = (units.toArray());
+    CandidateUnit unit1 = (CandidateUnit) objs[0];
+    assertEquals(unit1.getName(), "analyze");
   }
 
   private JavaCompletion getCompletion() throws Exception {

--- a/server/src/test/java/meghanada/completion/JavaCompletionTest.java
+++ b/server/src/test/java/meghanada/completion/JavaCompletionTest.java
@@ -214,70 +214,71 @@ public class JavaCompletionTest extends GradleTestBase {
   public void testSmartCompletionNoType() throws Exception {
     JavaCompletion completion = getCompletion();
     File file =
-      new File(
-               project.getProjectRootPath(), "./src/main/java/meghanada/analyze/JavaAnalyzer.java")
-      .getCanonicalFile();
+        new File(
+                project.getProjectRootPath(), "./src/main/java/meghanada/analyze/JavaAnalyzer.java")
+            .getCanonicalFile();
     assertTrue(file.exists());
     final Collection<? extends CandidateUnit> units =
-      timeIt(() -> completion.completionAt(file, 88, 6, "*diagnostic*fileObject#"));
+        timeIt(() -> completion.completionAt(file, 88, 6, "*diagnostic*fileObject#"));
     units.forEach(a -> System.out.println(a.getDisplayDeclaration()));
     CandidateUnit unit = (CandidateUnit) (units.toArray())[0];
-    assertEquals(unit.getName(), "getSource");
+    assertEquals("getSource", unit.getName());
   }
 
   @Test
   public void testSmartCompletionWithType() throws Exception {
     JavaCompletion completion = getCompletion();
     File file =
-      new File(
-               project.getProjectRootPath(), "./src/main/java/meghanada/analyze/JavaAnalyzer.java")
-      .getCanonicalFile();
+        new File(
+                project.getProjectRootPath(), "./src/main/java/meghanada/analyze/JavaAnalyzer.java")
+            .getCanonicalFile();
     assertTrue(file.exists());
     final Collection<? extends CandidateUnit> units =
-      timeIt(() -> completion.completionAt(file, 88, 6, "*kind*String#"));
+        timeIt(() -> completion.completionAt(file, 88, 6, "*kind*String#"));
     units.forEach(a -> System.out.println(a.getDisplayDeclaration()));
     Object[] objs = (units.toArray());
     CandidateUnit unit1 = (CandidateUnit) objs[0];
     CandidateUnit unit2 = (CandidateUnit) objs[1];
-    assertEquals(unit1.getName(), "name");
-    assertEquals(unit2.getName(), "toString");
+    assertEquals("name", unit1.getName());
+    assertEquals("toString", unit2.getName());
   }
 
   @Test
   public void testSmartCompletionPrimaryType() throws Exception {
     JavaCompletion completion = getCompletion();
     File file =
-      new File(
-               project.getProjectRootPath(), "./src/main/java/meghanada/analyze/JavaAnalyzer.java")
-      .getCanonicalFile();
+        new File(
+                project.getProjectRootPath(), "./src/main/java/meghanada/analyze/JavaAnalyzer.java")
+            .getCanonicalFile();
     assertTrue(file.exists());
     final Collection<? extends CandidateUnit> units =
-      timeIt(() -> completion.completionAt(file, 304, 4, "*code*int#"));
+        timeIt(() -> completion.completionAt(file, 304, 4, "*code*int#"));
     units.forEach(a -> System.out.println(a.getDisplayDeclaration()));
     Object[] objs = (units.toArray());
     CandidateUnit unit1 = (CandidateUnit) objs[0];
     CandidateUnit unit2 = (CandidateUnit) objs[1];
     CandidateUnit unit3 = (CandidateUnit) objs[2];
     CandidateUnit unit4 = (CandidateUnit) objs[3];
-    assertEquals(unit1.getName(), "length");
-    assertEquals(unit2.getName(), "hashCode");
-    assertEquals(unit3.getName(), "indexOf");
-    assertEquals(unit4.getName(), "lastIndexOf");
+    assertEquals("length", unit1.getName());
+    assertEquals("hashCode", unit2.getName());
+    assertEquals("indexOf", unit3.getName());
+    assertEquals("lastIndexOf", unit4.getName());
   }
 
+  @Test
   public void testSmartCompletionGenericType() throws Exception {
     JavaCompletion completion = getCompletion();
     File file =
-      new File(
-               project.getProjectRootPath(), "./src/main/java/meghanada/analyze/JavaAnalyzer.java")
-      .getCanonicalFile();
+        new File(
+                project.getProjectRootPath(), "./src/main/java/meghanada/analyze/JavaAnalyzer.java")
+            .getCanonicalFile();
     assertTrue(file.exists());
     final Collection<? extends CandidateUnit> units =
-      timeIt(() -> completion.completionAt(file, 192, 22, "a"));
+        timeIt(() -> completion.completionAt(file, 192, 22, "a"));
     units.forEach(a -> System.out.println(a.getDisplayDeclaration()));
     Object[] objs = (units.toArray());
     CandidateUnit unit1 = (CandidateUnit) objs[0];
-    assertEquals(unit1.getName(), "analyze");
+    assertEquals("analyze", unit1.getName());
   }
 
   private JavaCompletion getCompletion() throws Exception {


### PR DESCRIPTION
1. Support smart completion(the method whose return value is same as the
   variable or field to be assigned will be shown before other candidates
   in auto completion menu)
2. Add netbeans config folder to .gitignore

Note: For detail feature description and behaviour of this implementation, please refer to 

https://github.com/mopemope/meghanada-emacs/pull/102

Partially addressed #51 

For detail information please refer to #51 