### PR TITLE
Jump to symbol

### DIFF
--- a/server/src/main/java/meghanada/location/LocationSearcher.java
+++ b/server/src/main/java/meghanada/location/LocationSearcher.java
@@ -333,6 +333,10 @@ public class LocationSearcher {
     this.project = project;
   }
 
+  public Optional<Location> searchSymbol(final String symbol) {
+    return Optional.<Location>ofNullable(this.getFQCNLocation(symbol));
+  }
+
   public Optional<Location> searchDeclarationLocation(
       final File file, final int line, final int column, final String symbol)
       throws ExecutionException, IOException {

--- a/server/src/main/java/meghanada/server/CommandHandler.java
+++ b/server/src/main/java/meghanada/server/CommandHandler.java
@@ -15,6 +15,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import meghanada.analyze.CompileResult;
 import meghanada.completion.LocalVariable;
 import meghanada.docs.declaration.Declaration;
@@ -226,6 +227,19 @@ public class CommandHandler {
   public void ping(final long id) {
     try {
       final String out = outputFormatter.ping(id, "pong");
+      writer.write(out);
+      writer.newLine();
+    } catch (Throwable t) {
+      writeError(id, t);
+    }
+  }
+
+  public void listSymbols(final long id) {
+    try {
+      String out =
+          outputFormatter.listSymbols(
+              id, session.listSymbols().stream().collect(Collectors.joining("\n")));
+      log.info(out);
       writer.write(out);
       writer.newLine();
     } catch (Throwable t) {

--- a/server/src/main/java/meghanada/server/CommandHandler.java
+++ b/server/src/main/java/meghanada/server/CommandHandler.java
@@ -233,6 +233,23 @@ public class CommandHandler {
     }
   }
 
+  public void jumpSymbol(
+      final long id, final String path, final String line, final String col, final String symbol) {
+    final int lineInt = Integer.parseInt(line);
+    final int columnInt = Integer.parseInt(col);
+    try {
+      final Location location =
+          session
+              .jumpSymbol(path, lineInt, columnInt, symbol)
+              .orElseGet(() -> new Location(path, lineInt, columnInt));
+      final String out = outputFormatter.jumpDeclaration(id, location);
+      writer.write(out);
+      writer.newLine();
+    } catch (Throwable t) {
+      writeError(id, t);
+    }
+  }
+
   public void jumpDeclaration(
       final long id, final String path, final String line, final String col, final String symbol) {
     final int lineInt = Integer.parseInt(line);

--- a/server/src/main/java/meghanada/server/OutputFormatter.java
+++ b/server/src/main/java/meghanada/server/OutputFormatter.java
@@ -34,6 +34,8 @@ public interface OutputFormatter {
 
   String switchTest(long id, String openPath);
 
+  String listSymbols(Long id, String s);
+
   String jumpDeclaration(long id, Location location);
 
   String clearCache(long id, boolean result);

--- a/server/src/main/java/meghanada/server/emacs/EmacsServer.java
+++ b/server/src/main/java/meghanada/server/emacs/EmacsServer.java
@@ -244,9 +244,17 @@ public class EmacsServer implements Server {
             .when(headTail(eq("js"), any()))
             .get(
                 args -> {
-                  // jd : Jump Symbol
+                  // js : Jump Symbol
                   // usage: js <filepath> <line> <column> <symbol>
                   handler.jumpSymbol(id, args.get(0), args.get(1), args.get(2), args.get(3));
+                  return true;
+                })
+            .when(headTail(eq("ls"), any()))
+            .get(
+                args -> {
+                  // ls : List Symbols
+                  // usage: ls
+                  handler.listSymbols(id);
                   return true;
                 })
             .when(headTail(eq("sd"), any()))

--- a/server/src/main/java/meghanada/server/emacs/EmacsServer.java
+++ b/server/src/main/java/meghanada/server/emacs/EmacsServer.java
@@ -241,6 +241,14 @@ public class EmacsServer implements Server {
                   handler.jumpDeclaration(id, args.get(0), args.get(1), args.get(2), args.get(3));
                   return true;
                 })
+            .when(headTail(eq("js"), any()))
+            .get(
+                args -> {
+                  // jd : Jump Symbol
+                  // usage: js <filepath> <line> <column> <symbol>
+                  handler.jumpSymbol(id, args.get(0), args.get(1), args.get(2), args.get(3));
+                  return true;
+                })
             .when(headTail(eq("sd"), any()))
             .get(
                 args -> {

--- a/server/src/main/java/meghanada/server/formatter/SexpOutputFormatter.java
+++ b/server/src/main/java/meghanada/server/formatter/SexpOutputFormatter.java
@@ -233,6 +233,11 @@ public class SexpOutputFormatter implements OutputFormatter {
   }
 
   @Override
+  public String listSymbols(Long id, String s) {
+    return success(doubleQuote(s));
+  }
+
+  @Override
   public String jumpDeclaration(final long id, final Location loc) {
     final String result =
         LPAREN

--- a/server/src/main/java/meghanada/session/Session.java
+++ b/server/src/main/java/meghanada/session/Session.java
@@ -690,6 +690,10 @@ public class Session {
     return Optional.empty();
   }
 
+  public synchronized Set<String> listSymbols() throws ExecutionException, IOException {
+    return CachedASMReflector.getInstance().getGlobalClassIndex().keySet();
+  }
+
   public synchronized Optional<Location> jumpSymbol(
       final String path, final int line, final int column, final String symbol)
       throws ExecutionException, IOException {

--- a/server/src/main/java/meghanada/session/Session.java
+++ b/server/src/main/java/meghanada/session/Session.java
@@ -690,6 +690,23 @@ public class Session {
     return Optional.empty();
   }
 
+  public synchronized Optional<Location> jumpSymbol(
+      final String path, final int line, final int column, final String symbol)
+      throws ExecutionException, IOException {
+    final Optional<Location> location = this.getLocationSearcher().searchSymbol(symbol);
+
+    location.ifPresent(
+        a -> {
+          Location backLocation = new Location(path, line, column);
+          this.jumpDecHistory.addLast(backLocation);
+        });
+
+    if (!location.isPresent()) {
+      log.warn("can't find symbol={}.", symbol);
+    }
+    return location;
+  }
+
   public synchronized Optional<Location> jumpDeclaration(
       final String path, final int line, final int column, final String symbol)
       throws ExecutionException, IOException {

--- a/server/src/test/java/meghanada/docs/declaration/DeclarationSearcherTest.java
+++ b/server/src/test/java/meghanada/docs/declaration/DeclarationSearcherTest.java
@@ -45,7 +45,7 @@ public class DeclarationSearcherTest extends GradleTestBase {
 
     final DeclarationSearcher searcher = getSearcher();
     final Optional<Declaration> result =
-        timeIt(() -> searcher.searchDeclaration(f, 405, 17, "executorService"));
+        timeIt(() -> searcher.searchDeclaration(f, 413, 17, "executorService"));
     assertNotNull(result);
     assertTrue(result.isPresent());
     result.ifPresent(
@@ -88,7 +88,7 @@ public class DeclarationSearcherTest extends GradleTestBase {
     assertTrue(f.exists());
     final DeclarationSearcher searcher = getSearcher();
     final Optional<Declaration> result =
-        debugIt(() -> searcher.searchDeclaration(f, 405, 33, "submit"));
+        debugIt(() -> searcher.searchDeclaration(f, 413, 33, "submit"));
     assertNotNull(result);
     assertTrue(result.isPresent());
     result.ifPresent(
@@ -128,7 +128,7 @@ public class DeclarationSearcherTest extends GradleTestBase {
     assertTrue(f.exists());
     final DeclarationSearcher searcher = getSearcher();
     final Optional<Declaration> result =
-        debugIt(() -> searcher.searchDeclaration(f, 413, 53, "getOutputFormatter"));
+        debugIt(() -> searcher.searchDeclaration(f, 421, 53, "getOutputFormatter"));
     assertNotNull(result);
     assertTrue(result.isPresent());
     result.ifPresent(
@@ -259,7 +259,7 @@ public class DeclarationSearcherTest extends GradleTestBase {
 
     final DeclarationSearcher searcher = getSearcher();
     final Optional<Declaration> result =
-        timeIt(() -> searcher.searchDeclaration(f, 412, 34, "handler"));
+        timeIt(() -> searcher.searchDeclaration(f, 420, 34, "handler"));
     assertNotNull(result);
     assertTrue(result.isPresent());
     result.ifPresent(

--- a/server/src/test/java/meghanada/docs/declaration/DeclarationSearcherTest.java
+++ b/server/src/test/java/meghanada/docs/declaration/DeclarationSearcherTest.java
@@ -45,7 +45,7 @@ public class DeclarationSearcherTest extends GradleTestBase {
 
     final DeclarationSearcher searcher = getSearcher();
     final Optional<Declaration> result =
-        timeIt(() -> searcher.searchDeclaration(f, 413, 17, "executorService"));
+        timeIt(() -> searcher.searchDeclaration(f, 421, 17, "executorService"));
     assertNotNull(result);
     assertTrue(result.isPresent());
     result.ifPresent(
@@ -88,7 +88,7 @@ public class DeclarationSearcherTest extends GradleTestBase {
     assertTrue(f.exists());
     final DeclarationSearcher searcher = getSearcher();
     final Optional<Declaration> result =
-        debugIt(() -> searcher.searchDeclaration(f, 413, 33, "submit"));
+        debugIt(() -> searcher.searchDeclaration(f, 421, 33, "submit"));
     assertNotNull(result);
     assertTrue(result.isPresent());
     result.ifPresent(
@@ -128,7 +128,7 @@ public class DeclarationSearcherTest extends GradleTestBase {
     assertTrue(f.exists());
     final DeclarationSearcher searcher = getSearcher();
     final Optional<Declaration> result =
-        debugIt(() -> searcher.searchDeclaration(f, 421, 53, "getOutputFormatter"));
+        debugIt(() -> searcher.searchDeclaration(f, 429, 53, "getOutputFormatter"));
     assertNotNull(result);
     assertTrue(result.isPresent());
     result.ifPresent(
@@ -259,7 +259,7 @@ public class DeclarationSearcherTest extends GradleTestBase {
 
     final DeclarationSearcher searcher = getSearcher();
     final Optional<Declaration> result =
-        timeIt(() -> searcher.searchDeclaration(f, 420, 34, "handler"));
+        timeIt(() -> searcher.searchDeclaration(f, 428, 34, "handler"));
     assertNotNull(result);
     assertTrue(result.isPresent());
     result.ifPresent(

--- a/server/src/test/java/meghanada/location/LocationSearcherTest.java
+++ b/server/src/test/java/meghanada/location/LocationSearcherTest.java
@@ -193,11 +193,11 @@ public class LocationSearcherTest extends GradleTestBase {
 
     LocationSearcher searcher = getSearcher();
     Location result =
-        timeIt(() -> searcher.searchDeclarationLocation(f, 352, 20, "searchFieldAccess"))
+        timeIt(() -> searcher.searchDeclarationLocation(f, 356, 20, "searchFieldAccess"))
             .orElse(null);
     assertNotNull(result);
     assertTrue(result.getPath().contains("LocationSearcher.java"));
-    assertEquals(741, result.getLine());
+    assertEquals(745, result.getLine());
     assertEquals(30, result.getColumn());
   }
 
@@ -215,7 +215,7 @@ public class LocationSearcherTest extends GradleTestBase {
         timeIt(
                 () -> {
                   System.setProperty("disable-source-jar", "true");
-                  return searcher.searchDeclarationLocation(f, 626, 22, "decompileArchive");
+                  return searcher.searchDeclarationLocation(f, 630, 22, "decompileArchive");
                 })
             .orElse(null);
     assertNotNull(result);

--- a/server/src/test/java/meghanada/reference/ReferenceSearcherTest.java
+++ b/server/src/test/java/meghanada/reference/ReferenceSearcherTest.java
@@ -102,7 +102,7 @@ public class ReferenceSearcherTest extends GradleTestBase {
     assertNotNull(result);
     assertEquals(1, result.size());
     Reference reference = result.get(0);
-    assertEquals(728, reference.getLine());
+    assertEquals(745, reference.getLine());
   }
 
   @Test

--- a/server/src/test/java/meghanada/reference/ReferenceSearcherTest.java
+++ b/server/src/test/java/meghanada/reference/ReferenceSearcherTest.java
@@ -102,7 +102,7 @@ public class ReferenceSearcherTest extends GradleTestBase {
     assertNotNull(result);
     assertEquals(1, result.size());
     Reference reference = result.get(0);
-    assertEquals(745, reference.getLine());
+    assertEquals(749, reference.getLine());
   }
 
   @Test


### PR DESCRIPTION
This pull request adds two new commands:

- List symbols
- Jump to symbol

For now the only supported symbols are FQCN.

The commands can be used to jump to any known class in the project. No need to be referenced.

I will also send a pr for meghanada-emacs.