### PR TITLE
update maven-model-builder to release 3.6.3

### DIFF
--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -54,7 +54,7 @@ dependencies {
     val toolsJar = files("$javaHome/../lib/tools.jar")
     implementation(toolsJar)
     implementation("com.google.googlejavaformat:google-java-format:1.7")
-    implementation("org.apache.maven:maven-model-builder:3.6.1")
+    implementation("org.apache.maven:maven-model-builder:3.6.3")
     implementation("com.leacox.motif:motif:0.1")
     implementation("com.leacox.motif:motif-hamcrest:0.1")
     implementation("com.github.javaparser:javaparser-core:3.14.2")


### PR DESCRIPTION
Update maven-model-builder to release 3.6.3

This update will resolve this problem:
```
java.lang.NullPointerException: null
	at org.apache.maven.model.plugin.DefaultReportingConverter.convert(DefaultReportingConverter.java:243) ~[meghanada-1.2.0.jar:?]
	at org.apache.maven.model.plugin.DefaultReportingConverter.convert(DefaultReportingConverter.java:213) ~[meghanada-1.2.0.jar:?]
	at org.apache.maven.model.plugin.DefaultReportingConverter.convertReporting(DefaultReportingConverter.java:140) ~[meghanada-1.2.0.jar:?]
	at org.apache.maven.model.building.DefaultModelBuilder.build(DefaultModelBuilder.java:479) ~[meghanada-1.2.0.jar:?]
	at org.apache.maven.model.building.DefaultModelBuilder.build(DefaultModelBuilder.java:432) ~[meghanada-1.2.0.jar:?]
	at org.apache.maven.model.building.DefaultModelBuilder.build(DefaultModelBuilder.java:422) ~[meghanada-1.2.0.jar:?]
	at meghanada.project.maven.POMParser.parsePom(POMParser.java:90) ~[meghanada-1.2.0.jar:?]
	at meghanada.project.maven.MavenProject.parseProject(MavenProject.java:121) ~[meghanada-1.2.0.jar:?]
	at meghanada.session.Session.loadProject(Session.java:222) ~[meghanada-1.2.0.jar:?]
	at meghanada.session.Session.findProject(Session.java:142) ~[meghanada-1.2.0.jar:?]
	at meghanada.session.Session.createSession(Session.java:108) ~[meghanada-1.2.0.jar:?]
	at meghanada.session.Session.createSession(Session.java:102) ~[meghanada-1.2.0.jar:?]
	at meghanada.server.emacs.EmacsServer.startServer(EmacsServer.java:359) [meghanada-1.2.0.jar:?]
	at meghanada.Main.main(Main.java:156) [meghanada-1.2.0.jar:?]
```

when there is a section in pom.xml like this:
```
<reportSets>
  <reportSet>
    <reports>
      <!-- select non-aggregate reports -->
      <report>report</report>
    </reports>
  </reportSet>
</reportSets>
```

refer to:
> https://www.jacoco.org/jacoco/trunk/doc/maven.html